### PR TITLE
Add Excalidraw integration

### DIFF
--- a/turbo-discord/src/main/java/team2530/turbo_discord/Main.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/Main.java
@@ -9,6 +9,8 @@ import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import team2530.turbo_discord.commands.*;
+import team2530.turbo_discord.store.DataStore;
+import team2530.turbo_discord.store.ImageStore;
 
 import java.io.File;
 import java.util.Arrays;
@@ -18,6 +20,7 @@ import java.util.stream.Collectors;
 public class Main {
 
     public static final DataStore DATA_STORE = new DataStore(new File("./2024mnros"));
+    public static final ImageStore IMAGE_STORE = new ImageStore(new File("./2024mnros-images"));
 
     public static Command[] COMMANDS = {
             new EchoCommand(),

--- a/turbo-discord/src/main/java/team2530/turbo_discord/TurboListener.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/TurboListener.java
@@ -41,8 +41,6 @@ public class TurboListener extends ListenerAdapter {
             }
 
             Main.DATA_STORE.downloadAttachment(attachment);
-
-
         }
     }
 

--- a/turbo-discord/src/main/java/team2530/turbo_discord/TurboListener.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/TurboListener.java
@@ -29,15 +29,20 @@ public class TurboListener extends ListenerAdapter {
 
         // We only care about webhook messages from turbo scout in the webhook-data channel
         if(!event.isWebhookMessage()) return;
-        if(event.getGuildChannel().getIdLong() != 1289016808845738058L) return;
+        if (event.getGuildChannel().getIdLong() != 1289016808845738058L) return;
 
         // Download all attachments
         for (Message.Attachment attachment : event.getMessage().getAttachments()) {
-            try {
-                Main.DATA_STORE.downloadAttachment(attachment);
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to download attachment!", e);
+
+            // Images are a special case and must be handled separately
+            if (attachment.getContentType().startsWith("image/")) {
+                Main.IMAGE_STORE.downloadAttachment(attachment);
+                continue;
             }
+
+            Main.DATA_STORE.downloadAttachment(attachment);
+
+
         }
     }
 

--- a/turbo-discord/src/main/java/team2530/turbo_discord/commands/EntryListCommand.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/commands/EntryListCommand.java
@@ -6,7 +6,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.utils.FileUpload;
 import team2530.turbo_discord.Command;
 import team2530.turbo_discord.CommandOption;
-import team2530.turbo_discord.DataStore;
+import team2530.turbo_discord.store.DataStore;
 import team2530.turbo_discord.Main;
 
 import java.nio.charset.StandardCharsets;

--- a/turbo-discord/src/main/java/team2530/turbo_discord/commands/ViewCommand.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/commands/ViewCommand.java
@@ -13,7 +13,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.utils.FileUpload;
 import team2530.turbo_discord.Command;
 import team2530.turbo_discord.CommandOption;
-import team2530.turbo_discord.DataStore;
+import team2530.turbo_discord.store.DataStore;
 import team2530.turbo_discord.Main;
 
 public class ViewCommand extends Command {

--- a/turbo-discord/src/main/java/team2530/turbo_discord/commands/ViewCommand.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/commands/ViewCommand.java
@@ -1,6 +1,8 @@
 package team2530.turbo_discord.commands;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,25 +23,45 @@ public class ViewCommand extends Command {
     private static final Gson gson = new GsonBuilder().create();
 
     public ViewCommand() {
-        super("view", "View data json", new CommandOption[] {
-            new CommandOption(OptionType.INTEGER, "team", "Filter by team", true)
+        super("view", "View data json", new CommandOption[]{
+                new CommandOption(OptionType.INTEGER, "team", "Filter by team", true)
         });
     }
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        Stream<DataStore.Entry> entries = Main.DATA_STORE.getEntries().stream();
+        Stream<DataStore.Entry> entryStream = Main.DATA_STORE.getEntries().stream();
 
         if (event.getOption("team") != null)
-            entries = entries.filter(entry -> entry.getTeamNumber() == event.getOption("team", OptionMapping::getAsInt));
-       
-        String s = gson.toJson(entries.collect(Collectors.toList()));
+            entryStream = entryStream.filter(entry -> entry.getTeamNumber() == event.getOption("team", OptionMapping::getAsInt));
+
+
+        List<DataStore.Entry> entries = entryStream.collect(Collectors.toList());
+
+        String s = gson.toJson(entries);
 
         if (s.length() < 2000) {
             event.reply("```json\n" + s + "\n```").queue();
         } else {
             event.replyFiles(FileUpload.fromData(s.getBytes(StandardCharsets.UTF_8), "turbo-view-" + event.getOption("team").getAsInt() + ".json")).queue();
         }
+
+        List<String> imageIds = getImageIds(entries);
+        imageIds.forEach(imageId -> {
+            event.getChannel().sendFiles(FileUpload.fromData(Main.IMAGE_STORE.getImageFile(imageId).get())).queue();
+        });
     }
-    
+
+    private List<String> getImageIds(List<DataStore.Entry> entries) {
+        List<String> images = new ArrayList<>();
+
+        for (DataStore.Entry entry : entries) {
+            if (entry.getType().equals("strategy")) {
+                images.add(entry.getData().get("image").toString());
+            }
+        }
+
+        return images;
+    }
+
 }

--- a/turbo-discord/src/main/java/team2530/turbo_discord/store/DataStore.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/store/DataStore.java
@@ -1,15 +1,10 @@
-package team2530.turbo_discord;
+package team2530.turbo_discord.store;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
-import net.dv8tion.jda.api.entities.Message;
 
-import javax.net.ssl.HttpsURLConnection;
 import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
 
@@ -18,11 +13,8 @@ import static java.nio.file.StandardWatchEventKinds.*;
 /**
  * Manage the turbo-scout data storage directory
  */
-public class DataStore {
+public class DataStore extends Store {
     private static final Gson gson = new GsonBuilder().create();
-
-    // The folder in which all data files are stored.
-    private final File directory;
 
     /**
      * An ArrayList of entries that are loaded in memory
@@ -35,11 +27,9 @@ public class DataStore {
      * @param directory The directory to use
      */
     public DataStore(File directory) {
-        this.directory = directory;
-        this.entries = new ArrayList<>();
+        super(directory);
 
-        if (!directory.exists())
-            directory.mkdirs();
+        this.entries = new ArrayList<>();
 
         // Load all existing entries into memory
         loadDataStore();
@@ -114,33 +104,6 @@ public class DataStore {
         } catch (IOException | InterruptedException ex) {
             ex.printStackTrace();
         }
-    }
-
-    public void downloadAttachment(Message.Attachment attachment) throws IOException {
-        attachment.getProxy().downloadToFile(Paths.get(this.directory.getAbsolutePath() + File.separator + attachment.getFileName()).toFile());
-////        System.out.println(attachment.getUrl());
-////        System.out.println("proxy=" + attachment.getProxyUrl());
-//        final URL url = new URL(attachment.getProxyUrl());
-//
-//        HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
-//        connection.setRequestMethod("GET");
-//
-//        if (connection.getResponseCode() == HttpsURLConnection.HTTP_OK) {
-//            try (InputStream inputStream = new BufferedInputStream(connection.getInputStream());
-//                 FileOutputStream fileOutputStream = new FileOutputStream(attachment.getFileName())) {
-//
-//                byte[] buffer = new byte[1024];
-//                int bytesRead;
-//
-//                while ((bytesRead = inputStream.read(buffer, 0, buffer.length)) != -1) {
-//                    fileOutputStream.write(buffer, 0, bytesRead);
-//                }
-//            }
-//        } else {
-//            throw new IOException("Failed to download entry: " + connection.getResponseMessage());
-//        }
-//
-//        connection.disconnect();
     }
 
     public ArrayList<Entry> getEntries() {

--- a/turbo-discord/src/main/java/team2530/turbo_discord/store/ImageStore.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/store/ImageStore.java
@@ -1,0 +1,21 @@
+package team2530.turbo_discord.store;
+
+import team2530.turbo_discord.store.Store;
+
+import java.io.File;
+
+public class ImageStore extends Store {
+
+    private File directory;
+
+
+    /**
+     * Initializes a new image store
+     *
+     * @param directory The directory images are stored in
+     */
+    public ImageStore(File directory) {
+        super(directory);
+    }
+
+}

--- a/turbo-discord/src/main/java/team2530/turbo_discord/store/ImageStore.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/store/ImageStore.java
@@ -3,11 +3,10 @@ package team2530.turbo_discord.store;
 import team2530.turbo_discord.store.Store;
 
 import java.io.File;
+import java.nio.file.Paths;
+import java.util.Optional;
 
 public class ImageStore extends Store {
-
-    private File directory;
-
 
     /**
      * Initializes a new image store
@@ -16,6 +15,16 @@ public class ImageStore extends Store {
      */
     public ImageStore(File directory) {
         super(directory);
+    }
+
+    public Optional<File> getImageFile(String id) {
+        File file = Paths.get(this.directory.getAbsolutePath(), String.format("image-%s.png", id)).toFile();
+
+        if(file.exists()) {
+            return Optional.of(file);
+        }
+
+        return Optional.empty();
     }
 
 }

--- a/turbo-discord/src/main/java/team2530/turbo_discord/store/Store.java
+++ b/turbo-discord/src/main/java/team2530/turbo_discord/store/Store.java
@@ -1,0 +1,31 @@
+package team2530.turbo_discord.store;
+
+import net.dv8tion.jda.api.entities.Message;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+/**
+ * A generic store class used for storing files in a directory
+ */
+public class Store {
+
+    // The folder in which all files related to this store are located.
+    protected final File directory;
+
+    /**
+     * Initialize a new data store
+     * @param directory
+     */
+    protected Store(File directory) {
+        this.directory = directory;
+
+        if (!directory.exists())
+            directory.mkdirs();
+    }
+
+    public void downloadAttachment(Message.Attachment attachment) {
+        attachment.getProxy().downloadToFile(Paths.get(this.directory.getAbsolutePath() + File.separator + attachment.getFileName()).toFile());
+    }
+
+}

--- a/turbo-scout/package-lock.json
+++ b/turbo-scout/package-lock.json
@@ -8,6 +8,7 @@
       "name": "turbo-scout",
       "version": "2025",
       "dependencies": {
+        "@excalidraw/excalidraw": "^0.17.6",
         "@mantine/core": "^7.12.2",
         "@mantine/form": "^7.12.2",
         "@mantine/hooks": "^7.12.2",
@@ -839,6 +840,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@excalidraw/excalidraw": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.17.6.tgz",
+      "integrity": "sha512-fyCl+zG/Z5yhHDh5Fq2ZGmphcrALmuOdtITm8gN4d8w4ntnaopTXcTfnAAaU3VleDC6LhTkoLOTG6P5kgREiIg==",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.2.0",
+        "react-dom": "^17.0.2 || ^18.2.0"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/turbo-scout/package.json
+++ b/turbo-scout/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@excalidraw/excalidraw": "^0.17.6",
     "@mantine/core": "^7.12.2",
     "@mantine/form": "^7.12.2",
     "@mantine/hooks": "^7.12.2",

--- a/turbo-scout/src/form.tsx
+++ b/turbo-scout/src/form.tsx
@@ -29,7 +29,7 @@ export interface QuestionComponentProps {
 }
 
 export interface FormStore {
-    team: number | undefined | null,
+    team: number | undefined,
     data: {},
     setDataField: (id: string, obj: any) => void,
     getDataField: (id: string) => any,

--- a/turbo-scout/src/layout.tsx
+++ b/turbo-scout/src/layout.tsx
@@ -69,6 +69,7 @@ function NavButtons(props: Partial<NavButtonProps>) {
         <NavButton {...props} href="/" onClick={props.onClick}>Home</NavButton>
         <NavButton {...props} href="/pit" onClick={props.onClick}>Pit</NavButton>
         <NavButton {...props} href="/match" onClick={props.onClick}>Match</NavButton>
+        <NavButton {...props} href="/strategy" onClick={props.onClick}>Strategy</NavButton>
         <NavButton {...props} href="/share" onClick={props.onClick}>Share</NavButton>
     </>
 }

--- a/turbo-scout/src/main.tsx
+++ b/turbo-scout/src/main.tsx
@@ -15,6 +15,7 @@ import PitPage from './pages/pit';
 import SetupPage from './pages/setup';
 import MatchPage from './pages/match';
 import SharePage from './pages/share';
+import StrategyPage from './pages/strategy';
 
 const router = createHashRouter([
   {
@@ -33,6 +34,10 @@ const router = createHashRouter([
       {
         path: "/match",
         element: <MatchPage />
+      },
+      {
+        path: "/strategy",
+        element: <StrategyPage />
       },
       {
         path: "/share",

--- a/turbo-scout/src/pages/match.tsx
+++ b/turbo-scout/src/pages/match.tsx
@@ -36,7 +36,7 @@ export default function PitPage() {
                 />)}
 
                 <Button onClick={() => {
-                    addEntry({ ...store, type: "match", user: configuration?.profile, timestamp: new Date() });
+                    addEntry({ ...store, type: "match", user: configuration!.profile, timestamp: new Date() });
                     clearAllData();
                     window.scrollTo({ top: 0 })
                 }}>Save</Button>

--- a/turbo-scout/src/pages/pit.tsx
+++ b/turbo-scout/src/pages/pit.tsx
@@ -41,7 +41,7 @@ export default function PitPage() {
                 })}
 
                 <Button onClick={() => {
-                    addEntry({ ...store, type: "pit", user: configuration?.profile, timestamp: new Date() });
+                    addEntry({ ...store, type: "pit", user: configuration!.profile, timestamp: new Date() });
                     clearAllData();
                     window.scrollTo({ top: 0 })
                 }}>Save</Button>

--- a/turbo-scout/src/pages/share.tsx
+++ b/turbo-scout/src/pages/share.tsx
@@ -5,7 +5,7 @@ import DISCORD_CONFIG from "../config/discord.json";
 
 import { Accordion, Button, Card, Center, Container, Group, Stack, Textarea, ThemeIcon, UnstyledButton } from "@mantine/core";
 import { IconBrandDiscordFilled, IconDownload, IconQrcode } from "@tabler/icons-react";
-import { TurboStore, md5, useTurboStore } from "../state";
+import { TurboEntry, TurboImage, TurboStore, md5, useTurboStore } from "../state";
 import download from "downloadjs";
 import { modals } from "@mantine/modals";
 import QRCode from "react-qr-code";
@@ -79,7 +79,7 @@ export default function SharePage() {
         <Container size="md">
             <pre>
                 {/* TODO: display this in a better format */}
-                <EntryDisplayList entries={state.entries} />
+                <EntryDisplayList entries={state.entries} images={state.images} />
             </pre>
             <Center>
                 <Group>
@@ -92,19 +92,23 @@ export default function SharePage() {
     </BaseLayout>
 }
 
-function EntryDisplayList(props: { entries: any[] }) {
+function EntryDisplayList(props: { entries: TurboEntry[], images: TurboImage[] }) {
     if (props.entries.length == 0) return <p>No entries to display.</p>
-    return <Accordion>
-        {props.entries.map(entry => <EntryDisplay entry={entry} />)}
-    </Accordion>
+
+    return <Stack>
+        <Accordion>
+            {props.entries.map(entry => <EntryDisplay entry={entry} />)}
+        </Accordion>
+        {props.images.length != 0 && <p>You have {props.images.length} images collected at the moment.</p>}
+    </Stack>
 }
 
-function EntryDisplay(props: { entry: any }) {
+function EntryDisplay(props: { entry: TurboEntry }) {
     const { entry } = props;
     const hash = md5(JSON.stringify(entry));
 
-    return <Accordion.Item key={hash} value={`${entry['type']} entry for team ${entry['team']}`}>
-        <Accordion.Control>{`${entry['type']} entry for team ${entry['team']}`}</Accordion.Control>
+    return <Accordion.Item key={hash} value={`${entry.type} entry for team ${entry.team}`}>
+        <Accordion.Control>{`${entry.type} entry for team ${entry.team}`}</Accordion.Control>
         <Accordion.Panel>
             <Textarea readOnly resize="vertical">
                 {JSON.stringify(entry, undefined, "\t")}

--- a/turbo-scout/src/pages/strategy.tsx
+++ b/turbo-scout/src/pages/strategy.tsx
@@ -46,7 +46,7 @@ export default function StrategyPage() {
 
                 setDataField("image", canvas.toDataURL("image/png"));
 
-                addEntry(addEntry({ ...store, type: "strategy", user: configuration?.profile, timestamp: new Date() }));
+                addEntry({ ...store, type: "strategy", user: configuration!.profile, timestamp: new Date() });
                 clearAllData();
                 excalidrawAPI?.updateScene({}); //TODO: this does not work properly
             }}>Save</Button>

--- a/turbo-scout/src/pages/strategy.tsx
+++ b/turbo-scout/src/pages/strategy.tsx
@@ -9,6 +9,7 @@ import { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types/types";
 import { useTurboStore } from "../state";
 import { Configuration } from "./setup";
 import { useLocalStorage } from "@mantine/hooks";
+import { md5 } from "../state";
 
 const useStrategyStore = create<FormStore>(formStoreDefaults);
 
@@ -17,6 +18,7 @@ export default function StrategyPage() {
     const { setDataField, setTeam, clearAllData } = store;
 
     const addEntry = useTurboStore(s => s.addEntry);
+    const addImage = useTurboStore(s => s.addImage);
 
     const [configuration, _] = useLocalStorage<Configuration | undefined>({ key: "config", defaultValue: undefined });
 
@@ -44,9 +46,14 @@ export default function StrategyPage() {
                     })
                 });
 
-                setDataField("image", canvas.toDataURL("image/png"));
+                const imageURL = canvas.toDataURL("image/png");
+                const imageId = md5(imageURL);
+
+                setDataField("image", imageId);
 
                 addEntry({ ...store, type: "strategy", user: configuration!.profile, timestamp: new Date() });
+                addImage({ id: imageId, data: imageURL });
+
                 clearAllData();
                 excalidrawAPI?.updateScene({}); //TODO: this does not work properly
             }}>Save</Button>

--- a/turbo-scout/src/pages/strategy.tsx
+++ b/turbo-scout/src/pages/strategy.tsx
@@ -1,11 +1,55 @@
-import { Excalidraw } from "@excalidraw/excalidraw";
-import { Container } from "@mantine/core";
+import { Excalidraw, exportToCanvas } from "@excalidraw/excalidraw";
+import { Button, Container, Select } from "@mantine/core";
 import { BaseLayout } from "../layout";
+import EVENT_CONFIG from "../config/event.json";
+import React from "react";
+import { FormStore, formStoreDefaults } from "../form";
+import { create } from "zustand";
+import { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types/types";
+import { useTurboStore } from "../state";
+import { Configuration } from "./setup";
+import { useLocalStorage } from "@mantine/hooks";
+
+const useStrategyStore = create<FormStore>(formStoreDefaults);
 
 export default function StrategyPage() {
+    const store = useStrategyStore();
+    const { setDataField, setTeam, clearAllData } = store;
+
+    const addEntry = useTurboStore(s => s.addEntry);
+
+    const [configuration, _] = useLocalStorage<Configuration | undefined>({ key: "config", defaultValue: undefined });
+
+    const [excalidrawAPI, setExcalidrawAPI] = React.useState<ExcalidrawImperativeAPI | null>(null);
+
     return <BaseLayout>
-        <Container size="xl" style={{height: "70vh"}}>
-            <Excalidraw theme="dark" />
+        <Container size="xl" style={{ height: "70vh" }}>
+            <Excalidraw theme="dark" excalidrawAPI={(api) => setExcalidrawAPI(api)} />
+
+            <Select label="Team" placeholder="Select a team" searchable data={EVENT_CONFIG.teams.map(team => ({
+                value: team.team_number.toString(),
+                label: `${team.team_number}: ${team.nickname}`
+            }))} onChange={(v) => setTeam(parseInt(v!))} />
+
+            <Button onClick={async () => {
+                const { width, height, zoom } = excalidrawAPI!.getAppState();
+
+                const canvas = await exportToCanvas({
+                    elements: excalidrawAPI!.getSceneElements(),
+                    files: excalidrawAPI!.getFiles(),
+                    appState: excalidrawAPI!.getAppState(),
+                    getDimensions: () => ({
+                        width: width / zoom.value,
+                        height: height / zoom.value
+                    })
+                });
+
+                setDataField("image", canvas.toDataURL("image/png"));
+
+                addEntry(addEntry({ ...store, type: "strategy", user: configuration?.profile, timestamp: new Date() }));
+                clearAllData();
+                excalidrawAPI?.updateScene({}); //TODO: this does not work properly
+            }}>Save</Button>
         </Container>
     </BaseLayout>
 }

--- a/turbo-scout/src/pages/strategy.tsx
+++ b/turbo-scout/src/pages/strategy.tsx
@@ -1,0 +1,11 @@
+import { Excalidraw } from "@excalidraw/excalidraw";
+import { Container } from "@mantine/core";
+import { BaseLayout } from "../layout";
+
+export default function StrategyPage() {
+    return <BaseLayout>
+        <Container size="xl" style={{height: "70vh"}}>
+            <Excalidraw theme="dark" />
+        </Container>
+    </BaseLayout>
+}

--- a/turbo-scout/src/state.tsx
+++ b/turbo-scout/src/state.tsx
@@ -5,22 +5,32 @@ import { create } from 'zustand';
  * 
  * TODO: Store state in localstorage instead of in memory to prevent data loss
  *  --> https://github.com/pmndrs/zustand?tab=readme-ov-file#persist-middleware
+ * 
+ * TODO: Don't store images the same way as entries- it will slow everything down.
  */
 
 export interface TurboStore {
-    entries: any[];
-    addEntry: (entry: any) => any[];
+    entries: TurboEntry[];
+    addEntry: (entry: TurboEntry) => TurboEntry[];
     clearAll: () => void;
 }
 
 export const useTurboStore = create<TurboStore>((set: any) => ({
     entries: [],
-    addEntry: (entry: any) => set((state: TurboStore) => ({ 
+    addEntry: (entry: TurboEntry) => set((state: TurboStore) => ({
         ...state,
-        entries: [...state.entries, JSON.parse(JSON.stringify(entry))] 
+        entries: [...state.entries, JSON.parse(JSON.stringify(entry))]
     })),
-    clearAll: () => set((_: TurboStore) => ({entries: []}))
+    clearAll: () => set((_: TurboStore) => ({ entries: [] }))
 }));
+
+export interface TurboEntry {
+    type: "pit" | "match" | "strategy";
+    team: number | undefined;
+    user: string;
+    timestamp: Date;
+    data: any;
+}
 
 /**
  * 42-line MD5 hash implementation.
@@ -31,44 +41,45 @@ export const useTurboStore = create<TurboStore>((set: any) => ({
  * @returns A md5 hash.
  */
 export function md5(inputString: string) {
-    var hc="0123456789abcdef";
-    function rh(n: number)                                                                     {var j,s="";for(j=0;j<=3;j++) s+=hc.charAt((n>>(j*8+4))&0x0F)+hc.charAt((n>>(j*8))&0x0F);return s;}
-    function ad(x: number, y: number)                                                          {var l=(x&0xFFFF)+(y&0xFFFF);var m=(x>>16)+(y>>16)+(l>>16);return (m<<16)|(l&0xFFFF);}
-    function rl(n: number, c: number)                                                          {return (n<<c)|(n>>>(32-c));}
-    function cm(q: number, a: number, b: number, x: number, s: number, t: number)              {return ad(rl(ad(ad(a,q),ad(x,t)),s),b);}
-    function ff(a: number,b: number, c: number, d: number, x: number, s: number, t: number)    {return cm((b&c)|((~b)&d),a,b,x,s,t);}
-    function gg(a: number, b: number, c: number, d: number, x: number, s: number, t: number)   {return cm((b&d)|(c&(~d)),a,b,x,s,t);}
-    function hh(a: number, b: number, c: number, d: number, x: number, s: number, t: number)   {return cm(b^c^d,a,b,x,s,t);}
-    function ii(a: number, b: number, c: number, d: number, x: number, s: number, t: number)   {return cm(c^(b|(~d)),a,b,x,s,t);}
+    var hc = "0123456789abcdef";
+    function rh(n: number) { var j, s = ""; for (j = 0; j <= 3; j++) s += hc.charAt((n >> (j * 8 + 4)) & 0x0F) + hc.charAt((n >> (j * 8)) & 0x0F); return s; }
+    function ad(x: number, y: number) { var l = (x & 0xFFFF) + (y & 0xFFFF); var m = (x >> 16) + (y >> 16) + (l >> 16); return (m << 16) | (l & 0xFFFF); }
+    function rl(n: number, c: number) { return (n << c) | (n >>> (32 - c)); }
+    function cm(q: number, a: number, b: number, x: number, s: number, t: number) { return ad(rl(ad(ad(a, q), ad(x, t)), s), b); }
+    function ff(a: number, b: number, c: number, d: number, x: number, s: number, t: number) { return cm((b & c) | ((~b) & d), a, b, x, s, t); }
+    function gg(a: number, b: number, c: number, d: number, x: number, s: number, t: number) { return cm((b & d) | (c & (~d)), a, b, x, s, t); }
+    function hh(a: number, b: number, c: number, d: number, x: number, s: number, t: number) { return cm(b ^ c ^ d, a, b, x, s, t); }
+    function ii(a: number, b: number, c: number, d: number, x: number, s: number, t: number) { return cm(c ^ (b | (~d)), a, b, x, s, t); }
     function sb(x: string) {
-        var i;var nblk=((x.length+8)>>6)+1;var blks=new Array(nblk*16);for(i=0;i<nblk*16;i++) blks[i]=0;
-        for(i=0;i<x.length;i++) blks[i>>2]|=x.charCodeAt(i)<<((i%4)*8);
-        blks[i>>2]|=0x80<<((i%4)*8);blks[nblk*16-2]=x.length*8;return blks;
+        var i; var nblk = ((x.length + 8) >> 6) + 1; var blks = new Array(nblk * 16); for (i = 0; i < nblk * 16; i++) blks[i] = 0;
+        for (i = 0; i < x.length; i++) blks[i >> 2] |= x.charCodeAt(i) << ((i % 4) * 8);
+        blks[i >> 2] |= 0x80 << ((i % 4) * 8); blks[nblk * 16 - 2] = x.length * 8; return blks;
     }
-    var i,x=sb(""+inputString),a=1732584193,b=-271733879,c=-1732584194,d=271733878,olda,oldb,oldc,oldd;
-    for(i=0;i<x.length;i+=16) {olda=a;oldb=b;oldc=c;oldd=d;
-        a=ff(a,b,c,d,x[i+ 0], 7, -680876936);d=ff(d,a,b,c,x[i+ 1],12, -389564586);c=ff(c,d,a,b,x[i+ 2],17,  606105819);
-        b=ff(b,c,d,a,x[i+ 3],22,-1044525330);a=ff(a,b,c,d,x[i+ 4], 7, -176418897);d=ff(d,a,b,c,x[i+ 5],12, 1200080426);
-        c=ff(c,d,a,b,x[i+ 6],17,-1473231341);b=ff(b,c,d,a,x[i+ 7],22,  -45705983);a=ff(a,b,c,d,x[i+ 8], 7, 1770035416);
-        d=ff(d,a,b,c,x[i+ 9],12,-1958414417);c=ff(c,d,a,b,x[i+10],17,     -42063);b=ff(b,c,d,a,x[i+11],22,-1990404162);
-        a=ff(a,b,c,d,x[i+12], 7, 1804603682);d=ff(d,a,b,c,x[i+13],12,  -40341101);c=ff(c,d,a,b,x[i+14],17,-1502002290);
-        b=ff(b,c,d,a,x[i+15],22, 1236535329);a=gg(a,b,c,d,x[i+ 1], 5, -165796510);d=gg(d,a,b,c,x[i+ 6], 9,-1069501632);
-        c=gg(c,d,a,b,x[i+11],14,  643717713);b=gg(b,c,d,a,x[i+ 0],20, -373897302);a=gg(a,b,c,d,x[i+ 5], 5, -701558691);
-        d=gg(d,a,b,c,x[i+10], 9,   38016083);c=gg(c,d,a,b,x[i+15],14, -660478335);b=gg(b,c,d,a,x[i+ 4],20, -405537848);
-        a=gg(a,b,c,d,x[i+ 9], 5,  568446438);d=gg(d,a,b,c,x[i+14], 9,-1019803690);c=gg(c,d,a,b,x[i+ 3],14, -187363961);
-        b=gg(b,c,d,a,x[i+ 8],20, 1163531501);a=gg(a,b,c,d,x[i+13], 5,-1444681467);d=gg(d,a,b,c,x[i+ 2], 9,  -51403784);
-        c=gg(c,d,a,b,x[i+ 7],14, 1735328473);b=gg(b,c,d,a,x[i+12],20,-1926607734);a=hh(a,b,c,d,x[i+ 5], 4,    -378558);
-        d=hh(d,a,b,c,x[i+ 8],11,-2022574463);c=hh(c,d,a,b,x[i+11],16, 1839030562);b=hh(b,c,d,a,x[i+14],23,  -35309556);
-        a=hh(a,b,c,d,x[i+ 1], 4,-1530992060);d=hh(d,a,b,c,x[i+ 4],11, 1272893353);c=hh(c,d,a,b,x[i+ 7],16, -155497632);
-        b=hh(b,c,d,a,x[i+10],23,-1094730640);a=hh(a,b,c,d,x[i+13], 4,  681279174);d=hh(d,a,b,c,x[i+ 0],11, -358537222);
-        c=hh(c,d,a,b,x[i+ 3],16, -722521979);b=hh(b,c,d,a,x[i+ 6],23,   76029189);a=hh(a,b,c,d,x[i+ 9], 4, -640364487);
-        d=hh(d,a,b,c,x[i+12],11, -421815835);c=hh(c,d,a,b,x[i+15],16,  530742520);b=hh(b,c,d,a,x[i+ 2],23, -995338651);
-        a=ii(a,b,c,d,x[i+ 0], 6, -198630844);d=ii(d,a,b,c,x[i+ 7],10, 1126891415);c=ii(c,d,a,b,x[i+14],15,-1416354905);
-        b=ii(b,c,d,a,x[i+ 5],21,  -57434055);a=ii(a,b,c,d,x[i+12], 6, 1700485571);d=ii(d,a,b,c,x[i+ 3],10,-1894986606);
-        c=ii(c,d,a,b,x[i+10],15,   -1051523);b=ii(b,c,d,a,x[i+ 1],21,-2054922799);a=ii(a,b,c,d,x[i+ 8], 6, 1873313359);
-        d=ii(d,a,b,c,x[i+15],10,  -30611744);c=ii(c,d,a,b,x[i+ 6],15,-1560198380);b=ii(b,c,d,a,x[i+13],21, 1309151649);
-        a=ii(a,b,c,d,x[i+ 4], 6, -145523070);d=ii(d,a,b,c,x[i+11],10,-1120210379);c=ii(c,d,a,b,x[i+ 2],15,  718787259);
-        b=ii(b,c,d,a,x[i+ 9],21, -343485551);a=ad(a,olda);b=ad(b,oldb);c=ad(c,oldc);d=ad(d,oldd);
+    var i, x = sb("" + inputString), a = 1732584193, b = -271733879, c = -1732584194, d = 271733878, olda, oldb, oldc, oldd;
+    for (i = 0; i < x.length; i += 16) {
+        olda = a; oldb = b; oldc = c; oldd = d;
+        a = ff(a, b, c, d, x[i + 0], 7, -680876936); d = ff(d, a, b, c, x[i + 1], 12, -389564586); c = ff(c, d, a, b, x[i + 2], 17, 606105819);
+        b = ff(b, c, d, a, x[i + 3], 22, -1044525330); a = ff(a, b, c, d, x[i + 4], 7, -176418897); d = ff(d, a, b, c, x[i + 5], 12, 1200080426);
+        c = ff(c, d, a, b, x[i + 6], 17, -1473231341); b = ff(b, c, d, a, x[i + 7], 22, -45705983); a = ff(a, b, c, d, x[i + 8], 7, 1770035416);
+        d = ff(d, a, b, c, x[i + 9], 12, -1958414417); c = ff(c, d, a, b, x[i + 10], 17, -42063); b = ff(b, c, d, a, x[i + 11], 22, -1990404162);
+        a = ff(a, b, c, d, x[i + 12], 7, 1804603682); d = ff(d, a, b, c, x[i + 13], 12, -40341101); c = ff(c, d, a, b, x[i + 14], 17, -1502002290);
+        b = ff(b, c, d, a, x[i + 15], 22, 1236535329); a = gg(a, b, c, d, x[i + 1], 5, -165796510); d = gg(d, a, b, c, x[i + 6], 9, -1069501632);
+        c = gg(c, d, a, b, x[i + 11], 14, 643717713); b = gg(b, c, d, a, x[i + 0], 20, -373897302); a = gg(a, b, c, d, x[i + 5], 5, -701558691);
+        d = gg(d, a, b, c, x[i + 10], 9, 38016083); c = gg(c, d, a, b, x[i + 15], 14, -660478335); b = gg(b, c, d, a, x[i + 4], 20, -405537848);
+        a = gg(a, b, c, d, x[i + 9], 5, 568446438); d = gg(d, a, b, c, x[i + 14], 9, -1019803690); c = gg(c, d, a, b, x[i + 3], 14, -187363961);
+        b = gg(b, c, d, a, x[i + 8], 20, 1163531501); a = gg(a, b, c, d, x[i + 13], 5, -1444681467); d = gg(d, a, b, c, x[i + 2], 9, -51403784);
+        c = gg(c, d, a, b, x[i + 7], 14, 1735328473); b = gg(b, c, d, a, x[i + 12], 20, -1926607734); a = hh(a, b, c, d, x[i + 5], 4, -378558);
+        d = hh(d, a, b, c, x[i + 8], 11, -2022574463); c = hh(c, d, a, b, x[i + 11], 16, 1839030562); b = hh(b, c, d, a, x[i + 14], 23, -35309556);
+        a = hh(a, b, c, d, x[i + 1], 4, -1530992060); d = hh(d, a, b, c, x[i + 4], 11, 1272893353); c = hh(c, d, a, b, x[i + 7], 16, -155497632);
+        b = hh(b, c, d, a, x[i + 10], 23, -1094730640); a = hh(a, b, c, d, x[i + 13], 4, 681279174); d = hh(d, a, b, c, x[i + 0], 11, -358537222);
+        c = hh(c, d, a, b, x[i + 3], 16, -722521979); b = hh(b, c, d, a, x[i + 6], 23, 76029189); a = hh(a, b, c, d, x[i + 9], 4, -640364487);
+        d = hh(d, a, b, c, x[i + 12], 11, -421815835); c = hh(c, d, a, b, x[i + 15], 16, 530742520); b = hh(b, c, d, a, x[i + 2], 23, -995338651);
+        a = ii(a, b, c, d, x[i + 0], 6, -198630844); d = ii(d, a, b, c, x[i + 7], 10, 1126891415); c = ii(c, d, a, b, x[i + 14], 15, -1416354905);
+        b = ii(b, c, d, a, x[i + 5], 21, -57434055); a = ii(a, b, c, d, x[i + 12], 6, 1700485571); d = ii(d, a, b, c, x[i + 3], 10, -1894986606);
+        c = ii(c, d, a, b, x[i + 10], 15, -1051523); b = ii(b, c, d, a, x[i + 1], 21, -2054922799); a = ii(a, b, c, d, x[i + 8], 6, 1873313359);
+        d = ii(d, a, b, c, x[i + 15], 10, -30611744); c = ii(c, d, a, b, x[i + 6], 15, -1560198380); b = ii(b, c, d, a, x[i + 13], 21, 1309151649);
+        a = ii(a, b, c, d, x[i + 4], 6, -145523070); d = ii(d, a, b, c, x[i + 11], 10, -1120210379); c = ii(c, d, a, b, x[i + 2], 15, 718787259);
+        b = ii(b, c, d, a, x[i + 9], 21, -343485551); a = ad(a, olda); b = ad(b, oldb); c = ad(c, oldc); d = ad(d, oldd);
     }
-    return rh(a)+rh(b)+rh(c)+rh(d);
+    return rh(a) + rh(b) + rh(c) + rh(d);
 }

--- a/turbo-scout/src/state.tsx
+++ b/turbo-scout/src/state.tsx
@@ -12,6 +12,10 @@ import { create } from 'zustand';
 export interface TurboStore {
     entries: TurboEntry[];
     addEntry: (entry: TurboEntry) => TurboEntry[];
+
+    images: TurboImage[];
+    addImage: (image: TurboImage) => void;
+
     clearAll: () => void;
 }
 
@@ -21,7 +25,14 @@ export const useTurboStore = create<TurboStore>((set: any) => ({
         ...state,
         entries: [...state.entries, JSON.parse(JSON.stringify(entry))]
     })),
-    clearAll: () => set((_: TurboStore) => ({ entries: [] }))
+
+    images: [],
+    addImage: (image: TurboImage) => set((state: TurboStore) => ({
+        ...state,
+        images: [...state.images, image]
+    })),
+
+    clearAll: () => set((_: TurboStore) => ({ entries: [], images: [] }))
 }));
 
 export interface TurboEntry {
@@ -29,6 +40,11 @@ export interface TurboEntry {
     team: number | undefined;
     user: string;
     timestamp: Date;
+    data: any;
+}
+
+export interface TurboImage {
+    id: string; // A checksum of the image, used to identify images
     data: any;
 }
 

--- a/turbo-scout/vite.config.ts
+++ b/turbo-scout/vite.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
     port: 3000,
     strictPort: true
   },
+  define: {
+    "process.env.IS_PREACT": JSON.stringify("false"),
+  },
   base: "/"
 })


### PR DESCRIPTION
This PR adds a new strategy scouting page to turbo-scout. This page makes use of [Excalidraw](https://excalidraw.com/) for drawing and diagram creation inside of turbo-scout. 

### Progress Tracker

- [x] Install excalidraw dependency
- [x] Add minimal excalidraw integration
- [x] Ensure turbo-scout is capable of handling image data sustainably
- [x] Implement saving excalidraw drawings to turbo-scout entries
- Add an excalidraw [library](https://github.com/excalidraw/excalidraw/blob/70e0e8dc2904d4bc3938858760f8da46c63783cf/packages/excalidraw/types.ts#L459) that contains typical FRC game elements. (Please see the comment below about excalidraw not supporting images in libraries.)
- [x] Update the discord bot backend with commands for viewing images