### PR TITLE
Encode webhook url with base64

### DIFF
--- a/turbo-scout/src/config/discord.json
+++ b/turbo-scout/src/config/discord.json
@@ -1,3 +1,4 @@
 {
-    "webhook": "https://discord.com/api/webhooks/1339342757201838131/paxULbP0tjvxINlFy83JfZ9wqC2fQoYXShEkOLACp2_JURAncazJ5tZFkPH_C4VXEnH3"
+    "notice": "The webhook url has been encoded in base64 to prevent systems from scraping it off of github and then automatically spamming it with undesired content. This is not meant to hide the webhook, merely to prevent automated systems from finding it.",
+    "webhook_base64": "aHR0cHM6Ly9kaXNjb3JkLmNvbS9hcGkvd2ViaG9va3MvMTMzOTM0Mjc1NzIwMTgzODEzMS9wYXhVTGJQMHRqdnhJTmxGeTgzSmZaOXdxQzJmUW9ZWFNoRWtPTEFDcDJfSlVSQW5jYXpKNXRaRmtQSF9DNFZYRW5IMw=="
 }

--- a/turbo-scout/src/pages/share.tsx
+++ b/turbo-scout/src/pages/share.tsx
@@ -31,7 +31,7 @@ const methods: ShareMethod[] = [
                 formData.append("file", file);
 
                 const xhr = new XMLHttpRequest();
-                xhr.open("POST", DISCORD_CONFIG.webhook);
+                xhr.open("POST", atob(DISCORD_CONFIG.webhook_base64));
                 xhr.send(formData);
             };
 


### PR DESCRIPTION
See the config file for more details - this is *ONLY* for preventing systems from recognizing it as a discord webhook.